### PR TITLE
Perform maintenance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,18 +12,21 @@ env:
   global:
     - "IMAGE=irap/docker-debian-ansible:stretch"
   matrix:
-    - "ANSIBLE_VERSION=2.4.3.0"
-    - "ANSIBLE_VERSION=2.3.3.0"
-    - "ANSIBLE_VERSION=2.2.3.0"
-    - "ANSIBLE_VERSION=2.1.6.0"
+    - "NTH_SUPPORTED_ANSIBLE_VERSION=1"
+    - "NTH_SUPPORTED_ANSIBLE_VERSION=2"
+    - "NTH_SUPPORTED_ANSIBLE_VERSION=3"
+    - "NTH_SUPPORTED_ANSIBLE_VERSION=4"
 language: "python"
 notifications:
   email: false
 python:
   - "2.7"
 script:
-  - "wget -O ${PWD}/run.sh https://raw.githubusercontent.com/pari-/docker-debian-ansible/master/run.sh"
-  - "chmod +x ${PWD}/run.sh"
-  - "${PWD}/run.sh"
+    - "wget -O ${PWD}/run.sh https://raw.githubusercontent.com/pari-/docker-debian-ansible/master/run.sh"
+    - "wget -O ${PWD}/extract_ansible_version.sh https://raw.githubusercontent.com/pari-/docker-debian-ansible/master/extract_ansible_version.sh"
+    - "wget -O ${PWD}/Dockerfile https://raw.githubusercontent.com/pari-/docker-debian-ansible/master/debian/stretch/Dockerfile"
+    - "chmod +x ${PWD}/run.sh"
+    - "chmod +x ${PWD}/extract_ansible_version.sh"
+    - 'export ANSIBLE_VERSION=$(./extract_ansible_version.sh Dockerfile ${NTH_SUPPORTED_ANSIBLE_VERSION}) && ${PWD}/run.sh'
 services: "docker"
 sudo: "required"

--- a/README.md
+++ b/README.md
@@ -19,12 +19,7 @@ An Ansible role which installs and configures the production process manager for
 
 Currently this role is developed for and tested on Debian GNU/Linux (release: stretch). It is assumed to work on other Debian distributions as well.
 
-Ansible version compatibility:
-
-- __2.4.3.0__ (current version in use for development of this role)
-- 2.3.3.0
-- 2.2.3.0
-- 2.1.6.0
+Ansible version compatibility: [Dockerfile](https://github.com/pari-/docker-debian-ansible/blob/master/debian/stretch/Dockerfile)
 
 ## Example
 
@@ -57,8 +52,8 @@ variable | default | notes
 `npm_name` | `pm2` | `The name of the 'pm2'-npm-package that is to be installed`
 `npm_production` | `yes` | `Install dependencies in production mode, excluding devDependencies`
 `startup_user` | `root` | `The user under which pm2's startup script is executed under`
-`supported_distro_list` | `['jessie', 'stretch']` | `A list of distribution releases this role supports`
-`version` | `2.10.1` | `Version of the 'pm2'-npm-package that is to be installed`
+`supported_distro_list` | `['stretch']` | `A list of distribution releases this role supports`
+`version` | `2.10.3` | `Version of the 'pm2'-npm-package that is to be installed`
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,5 @@ pm2_npm_name: "pm2"
 pm2_npm_production: "yes"
 pm2_startup_user: "root"
 pm2_supported_distro_list:
-  - "jessie"
   - "stretch"
-pm2_version: "2.10.1"
+pm2_version: "2.10.3"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,5 +13,4 @@ galaxy_info:
   platforms:
     - name: "Debian"
       versions:
-        - "jessie"
         - "stretch"


### PR DESCRIPTION
Integrate new 'Ansible Version'-testing mechanism
Drop Jessie support
Bump default 'pm2_version' from 2.10.1 to 2.10.3